### PR TITLE
Add unsafePartialBecause

### DIFF
--- a/src/Partial/Unsafe.js
+++ b/src/Partial/Unsafe.js
@@ -5,3 +5,14 @@
 exports.unsafePartial = function (f) {
   return f();
 };
+
+exports.unsafePartialBecause = function (reason) {
+  return function (f) {
+    try {
+      return exports.unsafePartial(f);
+    } catch (err) {
+      throw new Error("unsafePartial failed. The following " +
+                      "assumption was incorrect: '" + reason + "'.");
+    }
+  };
+};

--- a/src/Partial/Unsafe.purs
+++ b/src/Partial/Unsafe.purs
@@ -1,6 +1,7 @@
 -- | Utilities for working with partial functions.
 module Partial.Unsafe
   ( unsafePartial
+  , unsafePartialBecause
   , unsafeCrashWith
   ) where
 
@@ -8,6 +9,11 @@ import Partial (crashWith)
 
 -- | Discharge a partiality constraint, unsafely.
 foreign import unsafePartial :: forall a. (Partial => a) -> a
+
+-- | Discharge a partiality constraint, unsafely. Raises an exception with a
+-- | custom error message in the (unexpected) case where `unsafePartial` was
+-- | used incorrectly.
+foreign import unsafePartialBecause :: forall a. String -> (Partial => a) -> a
 
 -- | A function which crashes with the specified error message.
 unsafeCrashWith :: forall a. String -> a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,7 @@
 module Test.Main where
 
 import Partial (crashWith)
-import Partial.Unsafe (unsafePartial)
+import Partial.Unsafe (unsafePartial, unsafePartialBecause)
 
 f :: Partial => Int -> Int
 f 0 = 0
@@ -9,6 +9,9 @@ f _ = crashWith "f: partial function"
 
 safely :: Int
 safely = unsafePartial (f 0)
+
+safely2 :: Int
+safely2 = unsafePartialBecause "calling f with argument 0 is guaranteed to be safe" (f 0)
 
 main :: forall a. a -> {}
 main _ = {}


### PR DESCRIPTION
While updating code to PureScript 0.9, I find myself using `unsafePartial` quite a lot. This PR is a proposal to add a function `unsafePartialBecause` which would allow me to describe why using `unsafePartial` in a particular occasion is "guaranteed" to be safe:

``` purs
-- only works for strictly positive input:
g :: Partial => Int -> Int
g n | n > 0 = 1

h :: Int -> Int
h x = unsafePartialBecause "the argument to g is strictly positive" $ g (x * x)
```

In the unexpected case where the usage of `unsafePartial` was indeed unsafe (I forgot about the `x = 0` case ...), this would raise an exception with the custom error message:

```
> h 2
1

> h 0

Error: unsafePartial failed. The following assumption was incorrect:
'the argument to g is always positive'.
```
