### PR TITLE
Deprecate unsafePartialBecause; fixes #7

### DIFF
--- a/src/Partial/Unsafe.js
+++ b/src/Partial/Unsafe.js
@@ -5,14 +5,3 @@
 exports.unsafePartial = function (f) {
   return f();
 };
-
-exports.unsafePartialBecause = function (reason) {
-  return function (f) {
-    try {
-      return exports.unsafePartial(f);
-    } catch (err) {
-      throw new Error("unsafePartial failed. The following " +
-                      "assumption was incorrect: '" + reason + "'.");
-    }
-  };
-};

--- a/src/Partial/Unsafe.purs
+++ b/src/Partial/Unsafe.purs
@@ -10,10 +10,9 @@ import Partial (crashWith)
 -- | Discharge a partiality constraint, unsafely.
 foreign import unsafePartial :: forall a. (Partial => a) -> a
 
--- | Discharge a partiality constraint, unsafely. Raises an exception with a
--- | custom error message in the (unexpected) case where `unsafePartial` was
--- | used incorrectly.
-foreign import unsafePartialBecause :: forall a. String -> (Partial => a) -> a
+-- | *deprecated:* use `unsafePartial` instead.
+unsafePartialBecause :: forall a. String -> (Partial => a) -> a
+unsafePartialBecause _ x = unsafePartial x
 
 -- | A function which crashes with the specified error message.
 unsafeCrashWith :: forall a. String -> a


### PR DESCRIPTION
Is this how we deprecate things nowadays? I would have used a `Warn` constraint but I think that would necessitate a major bump, as previous 1.x.x versions of this library worked with older compilers.